### PR TITLE
Fix failing go checks

### DIFF
--- a/dummy-discovery/args/args.go
+++ b/dummy-discovery/args/args.go
@@ -28,7 +28,8 @@ var Tag = "snapshot"
 // Timestamp is the current timestamp
 var Timestamp = "unknown"
 
-func ParseArgs() {
+// Parse arguments passed by the user
+func Parse() {
 	for _, arg := range os.Args[1:] {
 		if arg == "" {
 			continue


### PR DESCRIPTION
This is also a breaking change for users of this library since we renamed the type `DiscoveryServer` to `Server` to avoid stuttering `discovery.DiscoveryServer`.