### PR TITLE
Add dummy-discovery link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This project is a library to ease implementation of pluggable discoveries for the [Arduino CLI](https://github.com/arduino/arduino-cli)
 following the [official specification](https://arduino.github.io/arduino-cli/latest/platform-specification/#pluggable-discovery).
 
+## Reference implementation
+
+The [`dummy-discovery` folder](dummy-discovery) contains a reference pluggable discovery implementation.
+
 ## Security
 
 If you think you found a vulnerability or other security-related bug in this project, please read our


### PR DESCRIPTION
The repository's dummy-discovery folder contains a reference pluggable discovery implementation. This will be a valuable resource for the users of the module so we should make sure they are aware of it from the start.