### PR TITLE
Sync "Check Go Dependencies" workflow with upstream

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Check for outdated cache
         id: diff
         run: |
-          git add --intent-to-add .
-          if ! git diff --color --exit-code; then
+          git add .
+          if ! git diff --cached --color --exit-code; then
             echo
             echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
             exit 1

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -2,7 +2,7 @@
 name: Check Go Dependencies
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.16"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -47,7 +47,7 @@ jobs:
           version: 3.x
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -73,7 +73,7 @@ jobs:
       # Some might find it convenient to have CI generate the cache rather than setting up for it locally
       - name: Upload cache to workflow artifact
         if: failure() && steps.diff.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
           name: dep-licenses-cache
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -95,7 +95,7 @@ jobs:
           version: 3.x
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.16"
 
-# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-go-dependencies-task.ya?ml"
@@ -34,7 +35,32 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check-cache:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -83,6 +109,8 @@ jobs:
           path: .licenses/
 
   check-deps:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -27,6 +27,9 @@ on:
       - "**/.gitmodules"
       - "**/go.mod"
       - "**/go.sum"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
A "Check Go Dependencies" GitHub Actions workflow is used to check whether all Go package dependencies of the modules in this repository use compatible licenses.

This workflow is hosted and maintained in a repository dedicated to a collection of such reusable Arduino tooling project assets.

Several enhancements have been made to the upstream file, but those had not yet been pulled into this repository:

- Bump action dependencies
- Correct and improve reference links:
  - https://github.com/arduino/tooling-project-assets/commit/e5dc77ebc43394a493771d54ae33997520162040
  - https://github.com/arduino/tooling-project-assets/commit/756af2a3feb7b408b9dd050c7c7d2a5ab24a49ca
- Detect unused dependency license metadata files
  https://github.com/arduino/tooling-project-assets/commit/0a66312592f9b2ff227a75ca6cadc557122b3730
- Add schedule event trigger to catch breakage caused by external changes
  https://github.com/arduino/tooling-project-assets/commit/e71e4702279bd165769efd830f276b6b492de92c
- Run workflow on release branch creation
  https://github.com/arduino/tooling-project-assets/commit/22504dc85c1bea37613506016e677cd545a9af1b
