### PR TITLE
Fix `HELLO` command handler for empty command input

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -132,7 +132,11 @@ func (d *Server) Run(in io.Reader, out io.Writer) error {
 
 		switch cmd {
 		case "HELLO":
-			d.hello(fullCmd[6:])
+			if len(fullCmd) < 7 {
+				d.hello("")
+			} else {
+				d.hello(fullCmd[6:])
+			}
 		case "START":
 			d.start()
 		case "LIST":

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -41,13 +41,29 @@ func TestDisc(t *testing.T) {
 
 	require.NoError(t, discovery.Start())
 
-	n, err := stdin.Write([]byte("quit\n"))
-	require.NoError(t, err)
-	require.Greater(t, n, 0)
-	output := [1024]byte{}
-	n, err = stdout.Read(output[:])
-	require.Greater(t, n, 0)
-	require.NoError(t, err)
+	{
+		// Check that discovery is able to handle an "hello" without parameters gracefully
+		// https://github.com/arduino/pluggable-discovery-protocol-handler/issues/32
+		inN, err := stdin.Write([]byte("hello\n"))
+		require.NoError(t, err)
+		require.Greater(t, inN, 0)
 
-	require.Equal(t, "{\n  \"eventType\": \"quit\",\n  \"message\": \"OK\"\n}\n", string(output[:n]))
+		output := [1024]byte{}
+		outN, err := stdout.Read(output[:])
+		require.Greater(t, outN, 0)
+		require.NoError(t, err)
+		require.Equal(t, "{\n  \"eventType\": \"hello\",\n  \"message\": \"Invalid HELLO command\",\n  \"error\": true\n}\n", string(output[:outN]))
+	}
+
+	{
+		inN, err := stdin.Write([]byte("quit\n"))
+		require.NoError(t, err)
+		require.Greater(t, inN, 0)
+
+		output := [1024]byte{}
+		outN, err := stdout.Read(output[:])
+		require.Greater(t, outN, 0)
+		require.NoError(t, err)
+		require.Equal(t, "{\n  \"eventType\": \"quit\",\n  \"message\": \"OK\"\n}\n", string(output[:outN]))
+	}
 }


### PR DESCRIPTION
Previously the discovery handler would not gracefully handle an empty `HELLO` command:

```
$ ./dummy-discovery
HELLO
panic: runtime error: slice bounds out of range [6:5]

goroutine 1 [running]:
github.com/arduino/pluggable-discovery-protocol-handler/v2.(*Server).Run(0xc00002c1e0, {0x5147c8?, 0xc000012010?}, {0x5147e8?, 0xc000012018?})
        /home/megabug/Workspace/pluggable-discovery-protocol-handler/discovery.go:135 +0x5a5
main.main()
        /home/megabug/Workspace/pluggable-discovery-protocol-handler/dummy-discovery/main.go:44 +0x88
$
```

After this patch, it is handled correctly:

```
$ ./dummy-discovery 
HELLO
{
  "eventType": "hello",
  "message": "Invalid HELLO command",
  "error": true
}
QUIT
{
  "eventType": "quit",
  "message": "OK"
}
$
```

Fix #32 
