### PR TITLE
Fix panic when dealing with crashing discoveries

### DIFF
--- a/client.go
+++ b/client.go
@@ -287,8 +287,6 @@ func (disc *Client) Run() (err error) {
 	} else if msg.ProtocolVersion > 1 {
 		return fmt.Errorf("protocol version not supported: requested 1, got %d", msg.ProtocolVersion)
 	}
-	disc.statusMutex.Lock()
-	defer disc.statusMutex.Unlock()
 	return nil
 }
 
@@ -307,8 +305,6 @@ func (disc *Client) Start() error {
 	} else if strings.ToUpper(msg.Message) != "OK" {
 		return fmt.Errorf("communication out of sync, expected 'OK', received '%s'", msg.Message)
 	}
-	disc.statusMutex.Lock()
-	defer disc.statusMutex.Unlock()
 	return nil
 }
 

--- a/dummy-discovery/args/args.go
+++ b/dummy-discovery/args/args.go
@@ -20,6 +20,7 @@ package args
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 // Tag is the current git tag
@@ -37,6 +38,14 @@ func Parse() {
 		if arg == "-v" || arg == "--version" {
 			fmt.Printf("dummy-discovery %s (build timestamp: %s)\n", Tag, Timestamp)
 			os.Exit(0)
+		}
+		if arg == "-k" {
+			// Emulate crashing discovery
+			go func() {
+				time.Sleep(time.Millisecond * 500)
+				os.Exit(1)
+			}()
+			continue
 		}
 		fmt.Fprintf(os.Stderr, "invalid argument: %s\n", arg)
 		os.Exit(1)


### PR DESCRIPTION
Previously, a pluggable discovery that crashed at startup would cause the client library to panic.

```
goroutine 11 [running]:
testing.tRunner.func1.2({0x5eaae0, 0x7db1f0})
	/home/cmaglie/Software/go1.22.3/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
	/home/cmaglie/Software/go1.22.3/src/testing/testing.go:1634 +0x377
panic({0x5eaae0?, 0x7db1f0?})
	/home/cmaglie/Software/go1.22.3/src/runtime/panic.go:770 +0x132
github.com/arduino/pluggable-discovery-protocol-handler/v2.(*Client).Run(0xc0000fa090)
	/home/cmaglie/Workspace/pluggable-discovery-protocol-handler/client.go:281 +0x16e
github.com/arduino/pluggable-discovery-protocol-handler/v2.TestClient.func1(0xc0000b31e0)
	/home/cmaglie/Workspace/pluggable-discovery-protocol-handler/client_test.go:108 +0xcc
testing.tRunner(0xc0000b31e0, 0x64c850)
	/home/cmaglie/Software/go1.22.3/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 9
	/home/cmaglie/Software/go1.22.3/src/testing/testing.go:1742 +0x390
exit status 2
```

This PR fixes this problem and cleans up the mutex usage in the library.

Related to https://github.com/arduino/arduino-cli/issues/2665.
