### PR TITLE
fix: deliver initial sync events instead of dropping them

### DIFF
--- a/client.go
+++ b/client.go
@@ -376,10 +376,10 @@ func (disc *Client) List() ([]*Port, error) {
 func (disc *Client) StartSync(size int) (eventChan <-chan *Event, retErr error) {
 	// Create the event channel *before* sending START_SYNC.
 	//
-	// A discovery may emit its initial "add" events as soon as it processes the
+	// A discovery may emit its initial "add" events very quickly after receiving the
 	// START_SYNC command, and those events can reach the client's decode loop
-	// before the "start_sync" success reply does (the discovery emits events from
-	// a separate goroutine, so the "add" and the "start_sync OK" reply race on the
+	// before disc.waitMessage returns (the discovery emits events from
+	// a separate goroutine, so the "start_sync OK" and the "add" reply race on the
 	// wire). If the event channel is still nil when such an "add" is decoded,
 	// jsonDecodeLoop silently drops it (see the eventChan nil checks there), and
 	// the port is lost until the next re-sync. Creating the channel up-front

--- a/client.go
+++ b/client.go
@@ -373,7 +373,34 @@ func (disc *Client) List() ([]*Port, error) {
 // It also creates a channel used to receive events from the pluggable discovery.
 // The event channel must be consumed as quickly as possible since it may block the
 // discovery if it becomes full. The channel size is configurable.
-func (disc *Client) StartSync(size int) (<-chan *Event, error) {
+func (disc *Client) StartSync(size int) (eventChan <-chan *Event, retErr error) {
+	// Create the event channel *before* sending START_SYNC.
+	//
+	// A discovery may emit its initial "add" events as soon as it processes the
+	// START_SYNC command, and those events can reach the client's decode loop
+	// before the "start_sync" success reply does (the discovery emits events from
+	// a separate goroutine, so the "add" and the "start_sync OK" reply race on the
+	// wire). If the event channel is still nil when such an "add" is decoded,
+	// jsonDecodeLoop silently drops it (see the eventChan nil checks there), and
+	// the port is lost until the next re-sync. Creating the channel up-front
+	// guarantees these initial events are delivered.
+	disc.statusMutex.Lock()
+	disc.stopSync()
+	c := make(chan *Event, size)
+	disc.eventChan = c
+	disc.statusMutex.Unlock()
+
+	// If START_SYNC does not complete successfully, tear down the event channel we
+	// just created so we don't leave a dangling channel that jsonDecodeLoop would
+	// keep feeding.
+	defer func() {
+		if retErr != nil {
+			disc.statusMutex.Lock()
+			disc.stopSync()
+			disc.statusMutex.Unlock()
+		}
+	}()
+
 	if err := disc.sendCommand("START_SYNC\n"); err != nil {
 		return nil, err
 	}
@@ -388,11 +415,5 @@ func (disc *Client) StartSync(size int) (<-chan *Event, error) {
 		return nil, fmt.Errorf("communication out of sync, expected 'OK', received '%s'", msg.Message)
 	}
 
-	// In case there is already an existing event channel in use we close it before creating a new one.
-	disc.statusMutex.Lock()
-	defer disc.statusMutex.Unlock()
-	disc.stopSync()
-	c := make(chan *Event, size)
-	disc.eventChan = c
 	return c, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -18,9 +18,11 @@
 package discovery
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -148,4 +150,78 @@ func TestClient(t *testing.T) {
 
 		cl.Quit()
 	})
+}
+
+func TestStartSyncDoesNotDropInitialEvents(t *testing.T) {
+	// Regression test: a discovery may emit its initial "add" event as soon as it
+	// receives START_SYNC, and that event can reach the client before the
+	// "start_sync" success reply. The client must not drop such an event.
+	//
+	// The netcat helper connects the client's stdio to this test's TCP socket, so
+	// we can inject the racy ordering (add before start_sync OK) deterministically.
+	builder, err := paths.NewProcess(nil, "go", "build")
+	require.NoError(t, err)
+	builder.SetDir("testdata/netcat")
+	require.NoError(t, builder.Run())
+
+	listener, err := net.ListenTCP("tcp", nil)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	disc := NewClient("test", "testdata/netcat/netcat", listener.Addr().String())
+	disc.SetLogger(&testLogger{})
+	require.NoError(t, disc.runProcess())
+	defer disc.Quit()
+
+	listener.SetDeadline(time.Now().Add(5 * time.Second))
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// StartSync sends START_SYNC and blocks until it receives the reply, so run it
+	// in the background and collect its result.
+	type startSyncResult struct {
+		ch  <-chan *Event
+		err error
+	}
+	resultCh := make(chan startSyncResult, 1)
+	go func() {
+		ch, err := disc.StartSync(10)
+		resultCh <- startSyncResult{ch, err}
+	}()
+
+	// Wait for the START_SYNC command to be sent, mirroring a real discovery that
+	// only emits events after being told to sync. At this point a correct client
+	// must already be ready to receive events.
+	connReader := bufio.NewReader(conn)
+	line, err := connReader.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "START_SYNC", strings.TrimSpace(line))
+
+	// Emit the initial "add" event *before* the "start_sync" success reply.
+	_, err = conn.Write([]byte(`{"eventType":"add","port":{"address":"/dev/ttyTEST","protocol":"serial"}}` + "\n"))
+	require.NoError(t, err)
+	_, err = conn.Write([]byte(`{"eventType":"start_sync","message":"OK"}` + "\n"))
+	require.NoError(t, err)
+
+	// StartSync must complete successfully.
+	var result startSyncResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartSync did not return")
+	}
+	require.NoError(t, result.err)
+	require.NotNil(t, result.ch)
+
+	// The initial "add" event must be delivered on the channel, not dropped.
+	select {
+	case ev, ok := <-result.ch:
+		require.True(t, ok, "event channel was closed instead of delivering the initial event")
+		require.Equal(t, "add", ev.Type)
+		require.NotNil(t, ev.Port)
+		require.Equal(t, "/dev/ttyTEST", ev.Port.Address)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the initial 'add' event was dropped")
+	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -154,11 +154,10 @@ func TestClient(t *testing.T) {
 
 func TestStartSyncDoesNotDropInitialEvents(t *testing.T) {
 	// Regression test: a discovery may emit its initial "add" event as soon as it
-	// receives START_SYNC, and that event can reach the client before the
-	// "start_sync" success reply. The client must not drop such an event.
+	// receives START_SYNC. The client must not drop such an event.
 	//
 	// The netcat helper connects the client's stdio to this test's TCP socket, so
-	// we can inject the racy ordering (add before start_sync OK) deterministically.
+	// we can inject the fast response deterministically.
 	builder, err := paths.NewProcess(nil, "go", "build")
 	require.NoError(t, err)
 	builder.SetDir("testdata/netcat")
@@ -198,10 +197,9 @@ func TestStartSyncDoesNotDropInitialEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "START_SYNC", strings.TrimSpace(line))
 
-	// Emit the initial "add" event *before* the "start_sync" success reply.
-	_, err = conn.Write([]byte(`{"eventType":"add","port":{"address":"/dev/ttyTEST","protocol":"serial"}}` + "\n"))
-	require.NoError(t, err)
-	_, err = conn.Write([]byte(`{"eventType":"start_sync","message":"OK"}` + "\n"))
+	// Emit the initial "add" very quickly after the START_SYNC response,
+	// simulating a very fast discovery. The client must not drop this event.
+	_, err = conn.Write([]byte(`{"eventType":"start_sync","message":"OK"}` + "\n" + `{"eventType":"add","port":{"address":"/dev/ttyTEST","protocol":"serial"}}` + "\n"))
 	require.NoError(t, err)
 
 	// StartSync must complete successfully.

--- a/client_test.go
+++ b/client_test.go
@@ -165,17 +165,17 @@ func TestStartSyncDoesNotDropInitialEvents(t *testing.T) {
 
 	listener, err := net.ListenTCP("tcp", nil)
 	require.NoError(t, err)
-	defer listener.Close()
+	t.Cleanup(func() { _ = listener.Close() })
 
 	disc := NewClient("test", "testdata/netcat/netcat", listener.Addr().String())
 	disc.SetLogger(&testLogger{})
 	require.NoError(t, disc.runProcess())
-	defer disc.Quit()
+	t.Cleanup(disc.Quit)
 
-	listener.SetDeadline(time.Now().Add(5 * time.Second))
+	require.NoError(t, listener.SetDeadline(time.Now().Add(5*time.Second)))
 	conn, err := listener.Accept()
 	require.NoError(t, err)
-	defer conn.Close()
+	t.Cleanup(func() { _ = conn.Close() })
 
 	// StartSync sends START_SYNC and blocks until it receives the reply, so run it
 	// in the background and collect its result.


### PR DESCRIPTION

A discovery process may emit its initial `add` events as soon as it receives the
`START_SYNC` command. Because a discovery emits events from a separate goroutine
(see `Server.startSync`, which calls `impl.StartSync(...)` and only afterwards
sends the `start_sync` reply), those `add` messages and the `start_sync` success
reply **race on the wire**.

On the client side, `Client.StartSync` only creates the event channel **after**
it has received the `start_sync` reply:

```go
sendCommand("START_SYNC")
waitMessage(...)          // wait for the "start_sync" OK reply
...
disc.eventChan = c        // event channel created only here
```

Meanwhile `jsonDecodeLoop` — which is already running (it is started in
`runProcess`) — drops any event that arrives while the channel is nil:

```go
if disc.eventChan != nil {
    disc.eventChan <- &Event{"add", msg.Port, disc.GetID()}
}   // else: silently dropped
```

So when the racy ordering happens (`add` arrives before `start_sync` OK), the
initial `add` is **silently dropped**. The port is then missing from the
consumer's view until the next re-sync, even though the discovery reported it
correctly. Because the event is dropped (not delayed), waiting longer after
`StartSync` does not recover it.

This manifests downstream (e.g. in Arduino CLI) as an intermittent empty
`board list` result: a board that is actually connected occasionally does not
show up, with no error.

## Change

Create the event channel **before** sending `START_SYNC`, so the client is ready
to receive events the moment the discovery starts emitting them:

```go
disc.statusMutex.Lock()
disc.stopSync()
c := make(chan *Event, size)
disc.eventChan = c
disc.statusMutex.Unlock()

// ... then send START_SYNC and wait for the reply
```

This is safe with respect to the handshake: command replies (`start_sync`,
`hello`, …) are routed to the command channel (`incomingMessagesChan`), while
`add`/`remove` events are routed to `eventChan`, so `waitMessage` still receives
the `start_sync` reply exactly as before.

If `START_SYNC` does not complete successfully, a deferred cleanup tears down the
channel that was created up-front, so no dangling event channel is left behind.

## Testing

Added `TestStartSyncDoesNotDropInitialEvents`, which uses the existing `netcat`
stdio helper to inject the racy ordering deterministically: it waits for the
`START_SYNC` command to be sent (mirroring a real discovery, which only emits
events after being told to sync), then writes an `add` event **before** the
`start_sync` OK reply, and asserts the event is delivered on the channel.

- On the current (unfixed) code the test fails with `the initial 'add' event was
  dropped`.
- With the fix the test passes.

The full existing test suite continues to pass.
